### PR TITLE
added, deployed, tested loopback sending avoidance

### DIFF
--- a/implementation-reports/falcon.md
+++ b/implementation-reports/falcon.md
@@ -81,7 +81,7 @@ Delete sending implementation in-progress.
 
 ### Security Considerations (4)
 
-* [ ] The sender avoids sending a Webmention to a loopback address (SHOULD)
+* [x] The sender avoids sending a Webmention to a loopback address (SHOULD)
 
 
 ### Extensions


### PR DESCRIPTION
added, deployed, tested loopback sending avoidance to Falcon on tantek.com, and confirmed no regressions. 

See addition of if check https://github.com/indieweb/link-rel-parser-php/blob/master/src/IndieWeb/get_rel_webmention.php#L39 and function is_loopback https://github.com/indieweb/link-rel-parser-php/blob/master/src/IndieWeb/get_rel_webmention.php#L12 for details of implementation.