### PR TITLE
Fix plugins list rendering

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -48,6 +48,7 @@ Some additional publishing software, portions of which are open source, supports
 ### Plugins
 
 Plugins exist for some open source publishing software
+
 * [Wordpress](https://wordpress.org/plugins/webmention/)
 * [Drupal](https://www.drupal.org/project/vinculum)
 * [Elgg](https://github.com/mapkyca/elgg-webmention)


### PR DESCRIPTION
I suspect the lack of space between the markdown list and the previous paragraph is causing the list to not render correctly, at https://webmention.net/implementations/#plugins.

![screenshot-2017-10-27 webmention](https://user-images.githubusercontent.com/74557/32102391-f0ca258c-bad0-11e7-9f5f-139a42e70a86.png)

Adding the newline will probably fix that.