### PR TITLE
Add django-webmention to receiving implementations

### DIFF
--- a/implementations/index.md
+++ b/implementations/index.md
@@ -26,6 +26,7 @@
 ### Receiving
 * PHP Minimum Viable Webmention handler: [https://gist.github.com/adactio/6484118](https://gist.github.com/adactio/6484118)
 * [pear2/Services_Linkback](https://github.com/pear2/Services_Linkback) - *PHP* Pingback and Webmention client + server library
+* [django-webmention](https://github.com/easy-as-python/django-webmention) - Webmention for Django projects
 
 ### Parsing
 * [microformats2 implementations and parsers](http://microformats.org/wiki/microformats2#Implementations)


### PR DESCRIPTION
Full disclosure: I'm the maintainer of `django-webmention`, an implementation that injects Webmention receiver headers in Django applications and collates received mentions in the Django administration interface.

Let me know if you'd like more information or if I can clarify anything!