### PR TITLE
Update URLs to indieweb/webmention-client-ruby

### DIFF
--- a/implementation-reports/transformative.md
+++ b/implementation-reports/transformative.md
@@ -4,15 +4,15 @@ Implementation Home Page URL: https://github.com/barryf/transformative
 
 Source Code repo URL(s):
 * https://github.com/barryf/transformative
-* https://github.com/indieweb/mention-client-ruby
+* https://github.com/indieweb/webmention-client-ruby
 * [x] 100% open source implementation
 
 Programming Language(s): Ruby
 
 Developer(s):
-- [Barry Frost](https://barryfrost.com) (transformative, mention-client-ruby)
-- [Nat Welch](http://natwelch.com) (mention-client-ruby)
-- [Aaron Parecki](https://aaronparecki.com/) (mention-client-ruby)
+- [Barry Frost](https://barryfrost.com) (transformative, webmention-client-ruby)
+- [Nat Welch](http://natwelch.com) (webmention-client-ruby)
+- [Aaron Parecki](https://aaronparecki.com/) (webmention-client-ruby)
 
 Implementation Classes: Sender and Receiver
 

--- a/implementations/index.md
+++ b/implementations/index.md
@@ -8,7 +8,7 @@
 ### Sending
 
 * [indieweb/mention-client-php](https://github.com/indieweb/mention-client-php) - *PHP* library for sending webmention and pingpack notifications
-* [indieweb/mention-client-ruby](https://github.com/indieweb/mention-client-ruby) - *Ruby* library for sending webmention notifications
+* [indieweb/webmention-client-ruby](https://github.com/indieweb/webmention-client-ruby) - *Ruby* library for sending webmention notifications
 * [phpish/webmention](https://github.com/phpish/webmention) - Simple Webmention client (non-OO) in *PHP* packaged as a composer package
 * [vrypan/webmention-tools](https://github.com/vrypan/webmention-tools) - *Python* client library and command line webmention sender
 * [pear2/Services_Linkback](https://github.com/pear2/Services_Linkback) - *PHP* Pingback and Webmention client + server library


### PR DESCRIPTION
Does what it says on the tin!

I believe I found all the references to `mention-client-ruby` and updated them to `webmention-client-ruby`. Let me know if I missed anything or if there's a build script or similar that needs running!